### PR TITLE
upgrade to tf 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env: TERRAFORM_VERSION=0.12.19
+
 addons:
   apt:
     packages:

--- a/iam.tf
+++ b/iam.tf
@@ -1,22 +1,22 @@
 module "role" {
   source = "git::https://github.com/cloudposse/terraform-aws-iam-role.git?ref=tags/0.4.0"
 
-  enabled = "${var.enabled}"
+  enabled = var.enabled
 
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("log"), list("group")))}"
-  tags       = "${var.tags}"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = compact(concat(var.attributes, ["log"], ["group"]))
+  tags       = var.tags
 
   role_description   = "Cloudwatch ${module.label.id} logs role"
   policy_description = "Cloudwatch ${module.label.id} logs policy"
 
-  principals = "${var.principals}"
+  principals = var.principals
 
   policy_documents = [
-    "${data.aws_iam_policy_document.log_agent.json}",
+    data.aws_iam_policy_document.log_agent.json,
   ]
 }
 
@@ -35,18 +35,13 @@ data "aws_iam_policy_document" "log_agent" {
       "logs:PutLogEvents",
     ]
 
-    resources = [
-      "${aws_cloudwatch_log_group.default.*.arn}",
-    ]
+    resources = aws_cloudwatch_log_group.default.*.arn
   }
 
   statement {
-    actions = [
-      "${var.additional_permissions}",
-    ]
+    actions = var.additional_permissions
 
-    resources = [
-      "${aws_cloudwatch_log_group.default.*.arn}",
-    ]
+    resources = aws_cloudwatch_log_group.default.*.arn
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -22,4 +22,3 @@ resource "aws_cloudwatch_log_stream" "default" {
   name           = element(var.stream_names, count.index)
   log_group_name = element(aws_cloudwatch_log_group.default.*.name, 0)
 }
-

--- a/main.tf
+++ b/main.tf
@@ -1,24 +1,25 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("log"), list("group")))}"
-  tags       = "${var.tags}"
-  enabled    = "${var.enabled}"
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = compact(concat(var.attributes, ["log"], ["group"]))
+  tags       = var.tags
+  enabled    = var.enabled
 }
 
 resource "aws_cloudwatch_log_group" "default" {
-  count             = "${var.enabled == "true" ? 1 : 0}"
-  name              = "${module.label.id}"
-  retention_in_days = "${var.retention_in_days}"
-  tags              = "${module.label.tags}"
-  kms_key_id        = "${var.kms_key_arn}"
+  count             = var.enabled == "true" ? 1 : 0
+  name              = module.label.id
+  retention_in_days = var.retention_in_days
+  tags              = module.label.tags
+  kms_key_id        = var.kms_key_arn
 }
 
 resource "aws_cloudwatch_log_stream" "default" {
-  count          = "${var.enabled == "true" && length(var.stream_names) > 0 ? length(var.stream_names) : 0}"
-  name           = "${element(var.stream_names, count.index)}"
-  log_group_name = "${element(aws_cloudwatch_log_group.default.*.name, 0)}"
+  count          = var.enabled == "true" && length(var.stream_names) > 0 ? length(var.stream_names) : 0
+  name           = element(var.stream_names, count.index)
+  log_group_name = element(aws_cloudwatch_log_group.default.*.name, 0)
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,25 @@
 output "log_group_arn" {
-  value       = "${join("", aws_cloudwatch_log_group.default.*.arn)}"
+  value       = join("", aws_cloudwatch_log_group.default.*.arn)
   description = "ARN of the log group"
 }
 
 output "stream_arns" {
-  value       = ["${aws_cloudwatch_log_stream.default.*.arn}"]
+  value       = [aws_cloudwatch_log_stream.default.*.arn]
   description = "ARN of the log stream"
 }
 
 output "log_group_name" {
   description = "Name of log group"
-  value       = "${join("", aws_cloudwatch_log_group.default.*.name)}"
+  value       = join("", aws_cloudwatch_log_group.default.*.name)
 }
 
 output "role_arn" {
-  value       = "${module.role.arn}"
+  value       = module.role.arn
   description = "ARN of role to assume"
 }
 
 output "role_name" {
-  value       = "${module.role.name}"
+  value       = module.role.name
   description = "Name of role to assume"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -10,28 +10,28 @@ variable "name" {
 
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
@@ -48,12 +48,12 @@ variable "retention_in_days" {
 
 variable "stream_names" {
   default     = []
-  type        = "list"
+  type        = list(string)
   description = "Names of streams"
 }
 
 variable "principals" {
-  type        = "map"
+  type        = map(string)
   description = "Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`)))"
 
   default = {
@@ -67,6 +67,7 @@ variable "additional_permissions" {
     "logs:DeleteLogStream",
   ]
 
-  type        = "list"
+  type        = list(string)
   description = "Additional permissions granted to assumed role"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "stream_names" {
 }
 
 variable "principals" {
-  type        = map(string)
+  type        = map(list(string))
   description = "Map of service name as key and a list of ARNs to allow assuming the role as value. (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`)))"
 
   default = {
@@ -70,4 +70,3 @@ variable "additional_permissions" {
   type        = list(string)
   description = "Additional permissions granted to assumed role"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Use ```terraform 0.12upgrade``` to update the module. 

This is dependent on the changes in https://github.com/cloudposse/terraform-aws-iam-role/pull/12 and requires the new child module tag version to be known before this should be considered complete. Once the other PR is merged, I can update the module version here, but wanted to get the PR out sooner rather than later.