### PR TITLE
Allow slash in log group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_log_group_label"></a> [log\_group\_label](#module\_log\_group\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.13.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
@@ -357,8 +357,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Hugo Samayoa][htplbc_avatar]][htplbc_homepage]<br/>[Hugo Samayoa][htplbc_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
-|---|---|---|---|
+|  [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Hugo Samayoa][htplbc_avatar]][htplbc_homepage]<br/>[Hugo Samayoa][htplbc_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [goruha_homepage]: https://github.com/goruha
@@ -369,6 +369,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [htplbc_avatar]: https://img.cloudposse.com/150x150/https://github.com/htplbc.png
   [korenyoni_homepage]: https://github.com/korenyoni
   [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -126,3 +126,5 @@ contributors:
     github: "htplbc"
   - name: "Yonatan Koren"
     github: "korenyoni"
+  - name: "RB"
+    github: "nitrocode"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_log_group_label"></a> [log\_group\_label](#module\_log\_group\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.13.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,4 @@
 locals {
-  enabled          = module.this.enabled
   iam_role_enabled = local.enabled && var.iam_role_enabled
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,27 @@
+locals {
+  enabled = module.this.enabled
+}
+
+module "log_group_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  # Allow forward slashes
+  regex_replace_chars = "/[^a-zA-Z0-9-\\/]/"
+
+  context = module.this.context
+}
+
 resource "aws_cloudwatch_log_group" "default" {
-  count             = module.this.enabled ? 1 : 0
-  name              = module.this.id
+  count             = local.enabled ? 1 : 0
+  name              = module.log_group_label.id
   retention_in_days = var.retention_in_days
-  tags              = module.this.tags
+  tags              = module.log_group_label.tags
   kms_key_id        = var.kms_key_arn
 }
 
 resource "aws_cloudwatch_log_stream" "default" {
-  count          = module.this.enabled && length(var.stream_names) > 0 ? length(var.stream_names) : 0
+  count          = local.enabled && length(var.stream_names) > 0 ? length(var.stream_names) : 0
   name           = element(var.stream_names, count.index)
   log_group_name = element(aws_cloudwatch_log_group.default.*.name, 0)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Custom label for cloudwatch log group name

## why
* Allow slash in log group names

## references
* https://sweetops.slack.com/archives/CB6GHNLG0/p1636985722167300

## test

```hcl
provider "aws" {
  region = "us-east-2"
}

module "cloudwatch_logs" {
  source = "github.com/cloudposse/terraform-aws-cloudwatch-logs?ref=allow-slash-log-group-names"

  name = "/aws/kinesisfirehose/aws-waf-logs-dev-app"
}
```

results in

```hcl
  # module.cloudwatch_logs.aws_cloudwatch_log_group.default[0] will be created
  + resource "aws_cloudwatch_log_group" "default" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "/aws/kinesisfirehose/aws-waf-logs-dev-app"
      + retention_in_days = 30
      + tags              = {
          + "Name" = "/aws/kinesisfirehose/aws-waf-logs-dev-app"
        }
      + tags_all          = {
          + "Name" = "/aws/kinesisfirehose/aws-waf-logs-dev-app"
        }
    }
```