### PR TITLE
Fix mistake in policy

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -375,7 +375,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cloudwatch-logs&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-cloudwatch-logs&utm_content=website
@@ -406,3 +406,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-cloudwatch-logs
   [share_email]: mailto:?subject=terraform-aws-cloudwatch-logs&body=https://github.com/cloudposse/terraform-aws-cloudwatch-logs
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-cloudwatch-logs?pixel&cs=github&cm=readme&an=terraform-aws-cloudwatch-logs
+<!-- markdownlint-restore -->

--- a/iam.tf
+++ b/iam.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "log_agent" {
     actions = var.additional_permissions
 
     resources = [
-      join("", aws_cloudwatch_log_group.default.*.arn),
+      "${join("", aws_cloudwatch_log_group.default.*.arn)}:*",
     ]
   }
 }


### PR DESCRIPTION
## what
Fix mistake in policy

## why
The policy is created simply by ARN without the ":" construct, which is necessary to create the correct policy for the role.
Without this ":" construct, the policy is created, but it does not work correctly.
This error was discovered when I tried to create a cloudwatch group in the cloudtrail module.
I got the response "Error: Error updating CloudTrail: InvalidCloudWatchLogsLogGroupArnException: Access denied. Verify in IAM that the role has adequate permissions."
After studying the code, I realized that I need to add the construction ":*" in a couple of lines.
My solution looks like this, I need to replace the lines in [file](https://github.com/cloudposse/terraform-aws-cloudwatch-logs/blob/master/iam.tf) :

This line:
join("", aws_cloudwatch_log_group.default.*.arn),
replaced by
"${join("", aws_cloudwatch_log_group.default.*.arn)}:*"
You need to do this in both identical lines.

Perhaps you can suggest a better solution, I'm new to terraforming.

## references
https://github.com/cloudposse/terraform-aws-cloudwatch-logs/issues/37
https://github.com/cloudposse/terraform-aws-cloudwatch-logs/blob/master/iam.tf#L55

