### PR TITLE
Pin IAM role version to `0.19.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 ```terraform
 module "cloudwatch_logs" {
@@ -146,7 +142,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_log_group_label"></a> [log\_group\_label](#module\_log\_group\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.16.2 |
+| <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.19.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_log_group_label"></a> [log\_group\_label](#module\_log\_group\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.16.2 |
+| <a name="module_role"></a> [role](#module\_role) | cloudposse/iam-role/aws | 0.19.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/iam.tf
+++ b/iam.tf
@@ -4,7 +4,7 @@ locals {
 
 module "role" {
   source  = "cloudposse/iam-role/aws"
-  version = "0.16.2"
+  version = "0.19.0"
 
   enabled = local.iam_role_enabled
 


### PR DESCRIPTION
## what

* Pin IAM role version to `0.19.0`

## why

* Fix Role name length limitation